### PR TITLE
Add Docker Compose setup to run app and expose Swagger UI (#1)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,10 @@
+__pycache__/
+*.pyc
+*.pyo
+*.pyd
+tests/
+.git
+.gitignore
+Dockerfile
+docker-compose.yml
+LICENSE

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,10 @@
+version: '3.8'
+
+services:
+  app:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    ports:
+      - "8020:8020"
+    restart: unless-stopped


### PR DESCRIPTION
## Summary

- Added `docker-compose.yml` to run the app using Docker Compose.
- Exposed port `8020` to access Swagger UI (`/docs`).
- Verified setup locally using `docker compose up --build`.

## How to Test

```bash
docker compose up --build

Visit http://localhost:8020/docs

Linked Issue
Closes #1 